### PR TITLE
Use empty db name for TableId on changes for DB2

### DIFF
--- a/debezium-connector-db2/pom.xml
+++ b/debezium-connector-db2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2Connection.java
+++ b/debezium-connector-db2/src/main/java/io/debezium/connector/db2/Db2Connection.java
@@ -302,7 +302,7 @@ public class Db2Connection extends JdbcConnection {
                  **/
                 changeTables.add(
                         new ChangeTable(
-                                new TableId(realDatabaseName, rs.getString(1), rs.getString(2)),
+                                new TableId("", rs.getString(1), rs.getString(2)),
                                 rs.getString(4),
                                 rs.getInt(9),
                                 Lsn.valueOf(rs.getBytes(5)),


### PR DESCRIPTION
Fix how TableIds are created when compiling table changes on DB2.